### PR TITLE
Added yp0 and yp1 parameter names to the run_methyl method so 1H/13C methyl spectra can be phased in the 13C (y) dimension

### DIFF
--- a/fidnet/__main__.py
+++ b/fidnet/__main__.py
@@ -129,6 +129,9 @@ def methyl(
         default=False, help="NMRPipe: dimension is left/right swapped"
     ),
     neg: bool = typer.Option(default=False, help="NMRPipe: dimension is reversed"),
+    yp0: float = typer.Option(default=0.0, help="13C phase correction"),
+    yp1: float = typer.Option(default=0.0, help="13C phase correction"),
+    blc: bool = typer.Option(default=False, help="NMRPipe baseline correction in 13C"),
 ):
     """FID-Net Decouple and improve resolution
     of spectra for uniformly 13C-1H labelled
@@ -148,6 +151,9 @@ def methyl(
         p0=p0,
         alt=alt,
         neg=neg,
+        yp0=yp0,
+        yp1=yp1,
+        blc=blc,
     )
 
 

--- a/fidnet/__main__.py
+++ b/fidnet/__main__.py
@@ -132,6 +132,8 @@ def methyl(
     yp0: float = typer.Option(default=0.0, help="13C phase correction"),
     yp1: float = typer.Option(default=0.0, help="13C phase correction"),
     blc: bool = typer.Option(default=False, help="NMRPipe baseline correction in 13C"),
+    yZF: int = typer.Option(default=1, help="Zero filling factor for 13C dimension"),
+    xZF: int = typer.Option(default=1, help="Zero filling factor for 1H dimension"),
 ):
     """FID-Net Decouple and improve resolution
     of spectra for uniformly 13C-1H labelled
@@ -154,6 +156,8 @@ def methyl(
         yp0=yp0,
         yp1=yp1,
         blc=blc,
+        yZF=yZF,
+        xZF=xZF,
     )
 
 

--- a/fidnet/experiments.py
+++ b/fidnet/experiments.py
@@ -87,6 +87,8 @@ def run_methyl(
     yp0: float = 0.0,
     yp1: float = 0.0,
     blc: bool = False,
+    yZF: int = 1,
+    xZF: int = 1,
 ):
     download_weights(config.weights_1h_methyl)
     download_weights(config.weights_13c_methyl)
@@ -102,6 +104,8 @@ def run_methyl(
         yp0=yp0,
         yp1=yp1,
         blc=blc,
+        yZF=yZF,
+        xZF=xZF,
     )
 
 
@@ -150,6 +154,8 @@ def run_examples(skip_3d: bool = True):
         yp0=0.0,
         yp1=0.0,
         blc=False,
+        yZF=1,
+        xZF=1,
     )
     print("\n6/7: Running aromatic side chain FID-Net2 example.")
     run_aromatic(

--- a/fidnet/experiments.py
+++ b/fidnet/experiments.py
@@ -84,6 +84,9 @@ def run_methyl(
     p0: float = 0.0,
     alt: bool = False,
     neg: bool = False,
+    yp0: float = 0.0,
+    yp1: float = 0.0,
+    blc: bool = False,
 ):
     download_weights(config.weights_1h_methyl)
     download_weights(config.weights_13c_methyl)
@@ -96,6 +99,9 @@ def run_methyl(
         p0=p0,
         alt=alt,
         neg=neg,
+        yp0=yp0,
+        yp1=yp1,
+        blc=blc,
     )
 
 
@@ -141,6 +147,9 @@ def run_examples(skip_3d: bool = True):
         p0=151.0,
         alt=True,
         neg=True,
+        yp0=0.0,
+        yp1=0.0,
+        blc=False,
     )
     print("\n6/7: Running aromatic side chain FID-Net2 example.")
     run_aromatic(

--- a/fidnet/methyl/run_methyl.py
+++ b/fidnet/methyl/run_methyl.py
@@ -23,7 +23,7 @@ def write_initial(input, outfile, com_file, min_1H, max_1H, p0):
         outy.write(f" -ov -out {outfile}")
 
 
-def write_intermediate1(input, outfile, com_file, alt, neg):
+def write_intermediate1(input, outfile, com_file, alt, neg, yp0, yp1):
     with open(com_file, "w") as outy:
         outy.write("#!/bin/csh \n")
         outy.write(f"nmrPipe -in {input} \\\n")
@@ -38,7 +38,7 @@ def write_intermediate1(input, outfile, com_file, alt, neg):
             outy.write("| nmrPipe  -fn FT -alt -neg  \\\n")
         else:
             outy.write("| nmrPipe  -fn FT -auto  \\\n")
-        outy.write("| nmrPipe  -fn PS -p0 0.00 -p1 0.00 -di -verb \\\n")
+        outy.write(f"| nmrPipe  -fn PS -p0 {yp0} -p1 {yp1} -di -verb \\\n")
         outy.write(f" -ov -out {outfile}")
 
 
@@ -54,7 +54,7 @@ def write_intermediate2(input, outfile, com_file):
         outy.write(f"-ov -out {outfile}")
 
 
-def write_final(input, outfile, com_file):
+def write_final(input, outfile, com_file, blc=False):
     with open(com_file, "w") as outy:
         outy.write("#!/bin/csh \n")
         outy.write(f"nmrPipe -in {input} \\\n")
@@ -62,7 +62,11 @@ def write_final(input, outfile, com_file):
         outy.write("| nmrPipe  -fn SP -off 0.42 -end 0.98  -pow 2 -c 0.5    \\\n")
         outy.write("| nmrPipe  -fn FT -auto      \\\n")
         outy.write("| nmrPipe  -fn PS -p0 0.00 -p1 0.00 -di -verb         \\\n")
+        if blc:
+            outy.write("| nmrPipe -fn POLY -auto -ord 2 \\\n")
         outy.write("| nmrPipe -fn TP       \\\n")
+        if blc:
+            outy.write("| nmrPipe -fn POLY -auto -ord 2 \\\n")
         outy.write(f" -ov -out {outfile}")
 
 
@@ -75,6 +79,9 @@ def run_net(
     p0=0.0,
     alt=False,
     neg=False,
+    yp0=0.0,
+    yp1=0.0,
+    blc=False,
 ):
     if not os.path.exists(outfolder):
         os.mkdir(outfolder)
@@ -98,6 +105,8 @@ def run_net(
         os.path.join(outfolder, "int2.com"),
         alt,
         neg,
+        yp0,
+        yp1,
     )
     os.system(f'/bin/csh {os.path.join(outfolder,"int2.com")}')
     write_intermediate2(
@@ -115,5 +124,6 @@ def run_net(
         os.path.join(outfolder, "int5.ft1"),
         os.path.join(outfolder, outfile),
         os.path.join(outfolder, "fin.com"),
+        blc,
     )
     os.system(f'/bin/csh {os.path.join(outfolder,"fin.com")}')

--- a/fidnet/methyl/run_methyl.py
+++ b/fidnet/methyl/run_methyl.py
@@ -16,20 +16,20 @@ def write_initial(input, outfile, com_file, min_1H, max_1H, p0):
         outy.write("#!/bin/csh \n")
         outy.write(f"nmrPipe -in {input} \\\n")
         outy.write("| nmrPipe  -fn EM -lb 0.5 -c 0.5 \\\n")
-        outy.write("| nmrPipe  -fn ZF -auto  \\\n")
+        outy.write("| nmrPipe  -fn ZF -auto \\\n")
         outy.write("| nmrPipe  -fn FT -auto  \\\n")
         outy.write(f"| nmrPipe  -fn PS -p0 {p0} -p1 0.00 -di -verb \\\n")
         outy.write(f"| nmrPipe  -fn EXT -x1 {min_1H}ppm -xn {max_1H}ppm -sw \\\n")
         outy.write(f" -ov -out {outfile}")
 
 
-def write_intermediate1(input, outfile, com_file, alt, neg, yp0, yp1):
+def write_intermediate1(input, outfile, com_file, alt, neg, yp0, yp1, yZF):
     with open(com_file, "w") as outy:
         outy.write("#!/bin/csh \n")
         outy.write(f"nmrPipe -in {input} \\\n")
         outy.write("| nmrPipe -fn TP  \\\n")
         outy.write("| nmrPipe  -fn SP -off 0.42 -end 0.98  -pow 2 -c 0.5    \\\n")
-        outy.write("| nmrPipe  -fn ZF -auto  \\\n")
+        outy.write(f"| nmrPipe  -fn ZF -auto  -zf {yZF}\\\n")
         if alt and neg:
             outy.write("| nmrPipe  -fn FT -alt -neg  \\\n")
         elif alt:
@@ -54,12 +54,13 @@ def write_intermediate2(input, outfile, com_file):
         outy.write(f"-ov -out {outfile}")
 
 
-def write_final(input, outfile, com_file, blc=False):
+def write_final(input, outfile, com_file, blc=False, xZF=1):
     with open(com_file, "w") as outy:
         outy.write("#!/bin/csh \n")
         outy.write(f"nmrPipe -in {input} \\\n")
         outy.write("| nmrPipe -fn TP   \\\n")
         outy.write("| nmrPipe  -fn SP -off 0.42 -end 0.98  -pow 2 -c 0.5    \\\n")
+        outy.write(f"| nmrPipe  -fn ZF -auto  -zf {xZF}\\\n")
         outy.write("| nmrPipe  -fn FT -auto      \\\n")
         outy.write("| nmrPipe  -fn PS -p0 0.00 -p1 0.00 -di -verb         \\\n")
         if blc:
@@ -82,6 +83,8 @@ def run_net(
     yp0=0.0,
     yp1=0.0,
     blc=False,
+    yZF=1,
+    xZF=1,
 ):
     if not os.path.exists(outfolder):
         os.mkdir(outfolder)
@@ -107,6 +110,7 @@ def run_net(
         neg,
         yp0,
         yp1,
+        yZF,
     )
     os.system(f'/bin/csh {os.path.join(outfolder,"int2.com")}')
     write_intermediate2(
@@ -125,5 +129,6 @@ def run_net(
         os.path.join(outfolder, outfile),
         os.path.join(outfolder, "fin.com"),
         blc,
+        xZF,
     )
     os.system(f'/bin/csh {os.path.join(outfolder,"fin.com")}')


### PR DESCRIPTION
Some 13C HMQC pulse programs don't have p0=0, p1=0 phasing for the 13C dimension. I've added code to set a 'yp0' and 'yp1' value to phase the indirect dimension. I've also added a '--blc' option so the 13C dimension can be baseline corrected with a POLY function in nmrPipe in both dimensions before writing out the final spectrum. 